### PR TITLE
fix: Add missing PostCSS configuration files to Tailwind templates

### DIFF
--- a/TEMPLATE_STRUCTURE_AUDIT_REPORT.md
+++ b/TEMPLATE_STRUCTURE_AUDIT_REPORT.md
@@ -51,20 +51,26 @@
 - ✅ `bun-react-tailwind`: Added .env.example, .gitignore
 - ✅ `vite-vue-tailwind`: Added .env.example, .gitignore
 
+### PostCSS Configuration Files
+
+- ✅ `nextjs-fullstack`: Added postcss.config.js for Tailwind CSS
+- ✅ `express-fullstack`: Added postcss.config.js for Tailwind CSS
+- ✅ `react-spa-advanced`: Added postcss.config.js for Tailwind CSS
+
 ## 📋 Template Completeness Matrix
 
-| Template           | .env.example | README.md | Dockerfile | docker-compose | .gitignore | TypeScript | Tests |
-| ------------------ | ------------ | --------- | ---------- | -------------- | ---------- | ---------- | ----- |
-| nextjs-fullstack   | ✅           | ✅        | ✅         | ✅             | ✅         | ✅         | ⚠️    |
-| express-fullstack  | ✅           | ✅        | ✅         | ✅             | ✅         | ✅         | ✅    |
-| react-spa-advanced | ✅           | ✅        | ✅         | ❌             | ✅         | ✅         | ✅    |
-| nextjs-app-router  | ✅           | ✅        | ✅         | ✅             | ❌         | ✅         | ⚠️    |
-| express-typescript | ✅           | ✅        | ✅         | ✅             | ❌         | ✅         | ⚠️    |
-| bun-react-tailwind | ✅           | ✅        | ❌         | ❌             | ✅         | ✅         | ❌    |
-| vite-vue-tailwind  | ✅           | ✅        | ❌         | ❌             | ✅         | ✅         | ❌    |
-| flask              | ✅           | ✅        | ❌         | ❌             | ❌         | ❌         | ❌    |
-| fastapi            | ✅           | ✅        | ❌         | ❌             | ❌         | ❌         | ❌    |
-| flask-bun-hybrid   | ✅           | ✅        | ❌         | ❌             | ❌         | ✅         | ❌    |
+| Template           | .env.example | README.md | Dockerfile | docker-compose | .gitignore | PostCSS | TypeScript | Tests |
+| ------------------ | ------------ | --------- | ---------- | -------------- | ---------- | ------- | ---------- | ----- |
+| nextjs-fullstack   | ✅           | ✅        | ✅         | ✅             | ✅         | ✅      | ✅         | ⚠️    |
+| express-fullstack  | ✅           | ✅        | ✅         | ✅             | ✅         | ✅      | ✅         | ✅    |
+| react-spa-advanced | ✅           | ✅        | ✅         | ❌             | ✅         | ✅      | ✅         | ✅    |
+| nextjs-app-router  | ✅           | ✅        | ✅         | ✅             | ❌         | ✅      | ✅         | ⚠️    |
+| express-typescript | ✅           | ✅        | ✅         | ✅             | ❌         | ❌      | ✅         | ⚠️    |
+| bun-react-tailwind | ✅           | ✅        | ❌         | ❌             | ✅         | ✅      | ✅         | ❌    |
+| vite-vue-tailwind  | ✅           | ✅        | ❌         | ❌             | ✅         | ✅      | ✅         | ❌    |
+| flask              | ✅           | ✅        | ❌         | ❌             | ❌         | ❌      | ❌         | ❌    |
+| fastapi            | ✅           | ✅        | ❌         | ❌             | ❌         | ❌      | ❌         | ❌    |
+| flask-bun-hybrid   | ✅           | ✅        | ❌         | ❌             | ❌         | ✅      | ✅         | ❌    |
 
 ## 🎯 Production Readiness Assessment
 

--- a/templates/express-fullstack/postcss.config.js
+++ b/templates/express-fullstack/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/templates/nextjs-fullstack/postcss.config.js
+++ b/templates/nextjs-fullstack/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/templates/react-spa-advanced/postcss.config.js
+++ b/templates/react-spa-advanced/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
- Add postcss.config.js to nextjs-fullstack template
- Add postcss.config.js to express-fullstack template
- Add postcss.config.js to react-spa-advanced template
- Update template completeness matrix to include PostCSS column
- Ensure all Tailwind CSS templates have proper PostCSS configuration

These files are required for Tailwind CSS to work properly with Vite and Next.js build systems.

